### PR TITLE
Fix: Skip monkey patch for sites without app installed

### DIFF
--- a/frappe_comment_xt/__init__.py
+++ b/frappe_comment_xt/__init__.py
@@ -4,7 +4,11 @@ __version__ = "0.0.1"
 
 
 def patch_add_comments_in_timeline():
+    import frappe
+    if "frappe_comment_xt" not in frappe.get_installed_apps():
+        return
     import frappe.desk.form.load as frappe_load
+
 
     from frappe_comment_xt.helpers.comment import add_comments_in_timeline
 

--- a/frappe_comment_xt/__init__.py
+++ b/frappe_comment_xt/__init__.py
@@ -6,6 +6,8 @@ __version__ = "0.0.1"
 def patch_add_comments_in_timeline():
     import frappe
 
+    # in shared bench this is required so it won't break other apps that use add_comments in their codebase.
+    # This is a safe check as the patch will only be applied if the app is installed in the site.
     if "frappe_comment_xt" not in frappe.get_installed_apps():
         return
     import frappe.desk.form.load as frappe_load

--- a/frappe_comment_xt/__init__.py
+++ b/frappe_comment_xt/__init__.py
@@ -5,10 +5,10 @@ __version__ = "0.0.1"
 
 def patch_add_comments_in_timeline():
     import frappe
+
     if "frappe_comment_xt" not in frappe.get_installed_apps():
         return
     import frappe.desk.form.load as frappe_load
-
 
     from frappe_comment_xt.helpers.comment import add_comments_in_timeline
 


### PR DESCRIPTION
## Description
In a shared bench setup with multiple sites, the `patch_add_comments_in_timeline` monkey patch was being applied globally during module initialization. This caused field missing errors for custom fields that the patched function relies on, even for sites that do not have `frappe_comment_xt` installed.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast
bench has the app but not installed in the site
<img width="947" height="273" alt="image" src="https://github.com/user-attachments/assets/77fb2225-3a44-4f5b-b685-cce00284835d" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
