### PR TITLE
fix: error due to no db conn during build

### DIFF
--- a/frappe_comment_xt/monkey_patch.py
+++ b/frappe_comment_xt/monkey_patch.py
@@ -6,7 +6,11 @@ def patch_add_comments_in_timeline():
 
     # in shared bench this is required so it won't break other apps that use add_comments in their codebase.
     # This is a safe check as the patch will only be applied if the app is installed in the site.
-    if "frappe_comment_xt" not in get_installed_apps():
+    try:
+        installed = get_installed_apps()
+    except Exception:
+        return
+    if "frappe_comment_xt" not in installed:
         return
     # A monkey patch was written for this function as it is used in many places within Frappe. Care was taken to avoid breaking existing code.
     try:


### PR DESCRIPTION
## Description
- at import time (triggered from hooks.py), but during bench build there's no site context/DB connection  so  wrap the get_installed_apps() call in a try/except to gracefully handle the no-site context during bench build

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

**Before**:
<img width="1179" height="417" alt="image" src="https://github.com/user-attachments/assets/ba40a1c5-88ff-4e33-b902-4c90cf7866b5" />

**After**:
<img width="1012" height="374" alt="image" src="https://github.com/user-attachments/assets/0cfbd95f-7467-420d-b4cd-842ec191285c" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
