### PR TITLE
fix: type annotations

### DIFF
--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import frappe
-from frappe.core.doctype.comment.comment import Comment
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.desk.form.document_follow import follow_document
@@ -7,6 +10,9 @@ from frappe.utils import strip_html_tags
 from frappe.utils.html_utils import clean_email_html
 
 from frappe_comment_xt.helpers.comment import filter_comments_by_visibility, get_mention_user, get_thread_participants
+
+if TYPE_CHECKING:
+    from frappe.core.doctype.comment.comment import Comment
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
@@ -123,18 +129,7 @@ def get_all_replies(reference_doctype: str, reference_name: str):
             "reference_doctype": reference_doctype,
             "reference_name": reference_name,
         },
-        fields=[
-            "name",
-            "owner",
-            "creation",
-            "modified",
-            "comment_type",
-            "comment_email",
-            "comment_by",
-            "content",
-            "custom_reply_to",
-            "custom_visibility",
-        ],
+        fields="*",
         order_by="creation DESC",
     )
     filtered_replies = filter_comments_by_visibility(replies, frappe.session.user)

--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 import frappe
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
@@ -8,9 +6,6 @@ from frappe.utils import strip_html_tags
 from frappe.utils.html_utils import clean_email_html
 
 from frappe_comment_xt.helpers.comment import filter_comments_by_visibility, get_mention_user, get_thread_participants
-
-if TYPE_CHECKING:
-    from frappe.core.doctype.comment.comment import Comment
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
@@ -22,7 +17,7 @@ def add_comment_override(
     comment_by: str,
     custom_visibility: str = "Visible to everyone",
     custom_reply_to: str | None = None,
-) -> Comment:
+):
     """Allow logged user with permission to read document to add a comment"""
     reference_doc = frappe.get_doc(reference_doctype, reference_name)
     reference_doc.check_permission()

--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -129,7 +129,18 @@ def get_all_replies(reference_doctype: str, reference_name: str):
             "reference_doctype": reference_doctype,
             "reference_name": reference_name,
         },
-        fields="*",
+        fields=[
+            "name",
+            "owner",
+            "creation",
+            "modified",
+            "comment_type",
+            "comment_email",
+            "comment_by",
+            "content",
+            "custom_reply_to",
+            "custom_visibility",
+        ],
         order_by="creation DESC",
     )
     filtered_replies = filter_comments_by_visibility(replies, frappe.session.user)

--- a/frappe_comment_xt/overrides/whitelist/comment.py
+++ b/frappe_comment_xt/overrides/whitelist/comment.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.core.doctype.comment.comment import Comment
 from frappe.core.doctype.file.utils import extract_images_from_html
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.desk.form.document_follow import follow_document
@@ -17,7 +18,7 @@ def add_comment_override(
     comment_by: str,
     custom_visibility: str = "Visible to everyone",
     custom_reply_to: str | None = None,
-):
+) -> Comment:
     """Allow logged user with permission to read document to add a comment"""
     reference_doc = frappe.get_doc(reference_doctype, reference_name)
     reference_doc.check_permission()


### PR DESCRIPTION
## Description

This PR add `from __future__ import annotations` which prevents annotations to cause runtime error.


## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

Full traceback:

### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    newargs = get_newargs(fn, kwargs)
  File "apps/frappe/frappe/__init__.py", line 1161, in get_newargs
    parameters, variable_kwargs_exist = _get_cached_signature_params(fn)
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "apps/frappe/frappe/__init__.py", line 1139, in _get_cached_signature_params
    signature = inspect.signature(fn)
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/inspect.py", line 3312, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                   globals=globals, locals=locals, eval_str=eval_str,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                   annotation_format=annotation_format)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/inspect.py", line 3027, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
                                    follow_wrapper_chains=follow_wrapped,
                                    globals=globals, locals=locals, eval_str=eval_str,
                                    annotation_format=annotation_format)
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/inspect.py", line 2502, in _signature_from_callable
    return _signature_from_function(sigcls, obj,
                                    skip_bound_arg=skip_bound_arg,
                                    globals=globals, locals=locals, eval_str=eval_str,
                                    annotation_format=annotation_format)
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/inspect.py", line 2325, in _signature_from_function
    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str,
                                  format=annotation_format)
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/annotationlib.py", line 890, in get_annotations
    ann = _get_dunder_annotations(obj)
  File "/workspace/.pyenv/versions/3.14.0/lib/python3.14/annotationlib.py", line 1059, in _get_dunder_annotations
    ann = getattr(obj, "__annotations__", None)
  File "apps/frappe_comment_xt/frappe_comment_xt/overrides/whitelist/comment.py", line 25, in __annotate__
    ) -> Comment:
         ^^^^^^^
NameError: name 'Comment' is not defined
```

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
